### PR TITLE
Open logging through runtime projections

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,17 +12,20 @@
 - Opening hosted services requests `gateway.serviceAccess.request` through the shared runtime.
 - Gateway UI stores `ServiceAccessContext` in runtime state and opens app URLs with a non-secret `serviceAccess` context id.
 - `serviceCapability` is opaque browser-carried CAAC material; Gateway UI does not inspect decrypted capability claims.
+- Opening Logging uses runtime service access and retained projection semantics; it does not pass raw logging API URLs to the app.
 
 ## Hosted Services
 - Hosted Services is the installed-service inventory for a gateway host.
 - The section focuses on service health, freshness, version, host gateway, and configuration posture.
 - Launch actions are optional and service-specific; NVR exposes Security Cameras actions, while storage can appear as a non-launcher service with health/config facts.
 - Logging appears as an installed hosted service with health/config facts and an optional open action for `constitute-logging-ui`.
+- The Logging open action launches the app surface only; log data arrives through account-runtime projections requested by generic service exchange and routed/attested by gateway.
 - Gateway UI should merge standalone service records and gateway `hostedServices` summaries into one installed-service view without duplicating rows.
 
 ## Planned
+- `constitute-service-manager` will project host/service lifecycle, configuration, deployment, and authorized remediation state into this surface later.
 - `constitute-cybersec` will project deeper host capability state into this surface later.
-- Gateway UI should surface host/service posture, while implementation remains in dedicated capability services.
+- Gateway UI should surface host/service posture, while implementation remains in dedicated capability services. Gateway UI must not become the service manager, firewall console, log interpreter, or security analyzer.
 - `constitute-physec` is a future app surface for Physical Security and should consume gateway/NVR/Zigbee projections rather than live inside Gateway UI.
 
 ## Retired

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import {
 } from "constitute-ui";
 import { BROKER } from "constitute-protocol";
 
-const RUNTIME_WORKER_VERSION = Object.freeze({ major: 2, minor: 9 });
+const RUNTIME_WORKER_VERSION = Object.freeze({ major: 2, minor: 12 });
 const RUNTIME_WORKER_BUILD_ID = `runtime-${RUNTIME_WORKER_VERSION.major}.${RUNTIME_WORKER_VERSION.minor}`;
 const RUNTIME_ATTACH_TIMEOUT_MS = 5_000;
 const RUNTIME_WRITE_TIMEOUT_MS = 10_000;
@@ -818,8 +818,8 @@ function renderServiceList(records) {
       }, !servicePk));
     } else if (service === "logging") {
       actions.appendChild(actionButton("Open Logging", () => {
-        openLogging(record);
-      }));
+        void openLogging(record);
+      }, !servicePk));
     }
     if (actions.childElementCount > 0) row.appendChild(actions);
     serviceListEl.appendChild(row);
@@ -1026,12 +1026,43 @@ async function openSecurityCameras(record, opts = {}) {
   }
 }
 
-function openLogging(record) {
-  const apiBaseUrl = String(record?.facts?.apiBaseUrl || "").trim();
-  const target = new URL("/constitute-logging-ui/", window.location.origin);
-  if (apiBaseUrl) target.searchParams.set("api", apiBaseUrl);
-  window.open(target.toString(), "_blank", "noopener,noreferrer");
-  addNotification("good", "Logging opened", "Opened the logging operator console.");
+async function openLogging(record) {
+  if (!runtimeReady) {
+    addNotification("warn", "Runtime unavailable", "Open constitute-account to hydrate the shared runtime first.");
+    return;
+  }
+  try {
+    const access = await runtimeBrokerCall(BROKER.SERVICE_ACCESS_REQUEST, {
+      payload: {
+        record,
+        options: {
+          service: "logging",
+          capability: "logging.view",
+        },
+      },
+    }, GATEWAY_ACTION_TIMEOUT_MS, "logging service access");
+    const contextId = randomOpaqueId("service-access");
+    const context = {
+      contextId,
+      app: "logging",
+      repo: "constitute-logging-ui",
+      identityId: String(runtimeSnapshot?.shell?.identity?.identityId || "").trim(),
+      devicePk: String(access?.servicePk || record?.devicePk || record?.pk || "").trim(),
+      gatewayPk: String(access?.gatewayPk || record?.hostGatewayPk || record?.devicePk || record?.pk || "").trim(),
+      servicePk: String(access?.servicePk || record?.devicePk || record?.pk || "").trim(),
+      service: "logging",
+      serviceCapability: String(access?.serviceCapability || "").trim(),
+      display: access?.display ?? {},
+      createdAt: Date.now(),
+      expiresAt: Number(access?.expiresAt || (Date.now() + (2 * 60 * 1000))),
+    };
+    await runtimeCall(BROKER.SERVICE_ACCESS_CONTEXT_PUT, { context }, RUNTIME_WRITE_TIMEOUT_MS);
+    const url = buildManagedSurfaceUrl("constitute-logging-ui", contextId);
+    window.open(url, "_blank", "noopener,noreferrer");
+    addNotification("good", "Logging opened", "Logging service access context was published to the shared runtime.");
+  } catch (error) {
+    addNotification("bad", "Logging service access failed", String(error?.message || error));
+  }
 }
 
 async function requestGatewayInstall(record) {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,8 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 test("gateway ui manifest shape stays stable", async () => {
   const manifest = await import("../app.manifest.json", { with: { type: "json" } });
   assert.equal(manifest.default.id, "constitute-gateway-ui");
   assert.equal(manifest.default.entry, "dist/index.html");
+});
+
+test("gateway ui uses the current shared runtime worker build", () => {
+  const source = readFileSync(resolve(here, "../src/main.js"), "utf8");
+  assert.match(source, /const RUNTIME_WORKER_VERSION = Object\.freeze\(\{ major: 2, minor: 12 \}\)/);
+  assert.match(source, /name: `constitute-account-runtime-\$\{RUNTIME_WORKER_BUILD_ID\}`/);
 });


### PR DESCRIPTION
## Summary
- Opens Logging without raw API URL hints.
- Keeps Hosted Services as installed service health/config inventory.

## Verification
- npm test
- npm run build