### PR TITLE
Adopt gateway surface posture helpers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import {
   browserStorageShellContext,
   deriveRuntimeShellState,
 } from "../../constitute-account/runtime-shell-state.js";
+import { gatewaySurfaceAttachContext } from "./surface-app-contract.js";
 
 const RUNTIME_ATTACH_TIMEOUT_MS = 5_000;
 const RUNTIME_WRITE_TIMEOUT_MS = 10_000;
@@ -410,6 +411,7 @@ function attachRuntime() {
     debug: debugEnabled,
     debugInfo: runtimeAttachDebugInfo(window.location.origin),
     logPrefix: "gateway-ui",
+    attachContext: gatewaySurfaceAttachContext,
     onPort: (port) => {
       runtimeDiagnosticsAgent = attachRuntimeDiagnostics({
         port,

--- a/src/main.js
+++ b/src/main.js
@@ -781,7 +781,7 @@ function renderServiceList(records) {
             <div>service ${escapeHtml(service || "unknown")}</div>
             <div>status <span class="gatewayStatusTone-${escapeHtml(toneForLabel(status))}">${escapeHtml(status)}</span></div>
             <div>host gateway ${escapeHtml(record.__hostGatewayLabel || shortPk(record?.hostGatewayPk || record?.host_gateway_pk || ""))}</div>
-            <div>source ${escapeHtml(record.__source === "serviceCatalog" ? "runtime catalog" : "runtime snapshot")}</div>
+            <div>source ${escapeHtml(record.__source === "serviceRegistry" ? "service registry" : record.__source === "serviceCatalog" ? "runtime catalog" : "runtime snapshot")}</div>
             <div>freshness ${escapeHtml(freshnessLabel(record))}</div>
             ${factRows.map((fact) => `<div>${escapeHtml(fact)}</div>`).join("")}
           </div>

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -1,3 +1,5 @@
+import { preparedServiceRegistry } from "../../constitute-ui/src/service-registry-model.js";
+
 function normalizedArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -122,9 +124,9 @@ function browserStorageManagedRecords(storage) {
 }
 
 function serviceCatalogRecords(snapshot) {
-  const catalog = normalizeObject(snapshot?.serviceCatalog);
-  const updatedAt = Number(catalog?.updatedAt || snapshot?.updatedAt || 0);
-  return normalizedArray(catalog?.services).flatMap((entry) => {
+  const registry = preparedServiceRegistry(snapshot || {});
+  const updatedAt = Number(registry.updatedAt || snapshot?.updatedAt || 0);
+  return normalizedArray(registry.services).flatMap((entry) => {
     if (!entry || typeof entry !== "object") return [];
     const service = normalizeRole(entry.service || "");
     const servicePk = String(entry.servicePk || entry.service_pk || "").trim();
@@ -145,7 +147,8 @@ function serviceCatalogRecords(snapshot) {
       },
       managedAvailabilityUpdatedAt: updatedAt,
       __scope: "runtime",
-      __source: "serviceCatalog",
+      __source: registry.source,
+      __registryState: registry.state,
     }];
   });
 }
@@ -256,12 +259,16 @@ export function prepareProjectionStatus(snapshot) {
 
 export function prepareRuntimeSnapshotModel(snapshot, options = {}) {
   const records = normalizeRuntimeRecords(snapshot, options);
-  const serviceCatalog = normalizeObject(snapshot?.serviceCatalog);
+  const registry = preparedServiceRegistry(snapshot || {});
   return {
     records,
     serviceCatalog: {
-      updatedAt: Number(serviceCatalog.updatedAt || 0),
-      serviceCount: normalizedArray(serviceCatalog.services).length,
+      updatedAt: Number(registry.updatedAt || 0),
+      serviceCount: registry.serviceCount,
+      source: registry.source,
+      state: registry.state,
+      claimCount: registry.claimCount,
+      entryCount: registry.entryCount,
     },
     edge: prepareSwarmEdgeStatus(snapshot),
     projection: prepareProjectionStatus(snapshot),
@@ -278,7 +285,7 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
     { label: "Projected records", value: String(normalizedArray(records).length), tone: "neutral" },
     {
       label: "Service catalog",
-      value: `${Number(serviceCatalog.serviceCount || 0)} services`,
+      value: `${Number(serviceCatalog.serviceCount || 0)} services / ${serviceCatalog.state || "unknown"}`,
       tone: Number(serviceCatalog.serviceCount || 0) > 0 ? "good" : "warn",
     },
     {

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -1,4 +1,5 @@
 import { preparedServiceRegistry } from "../../constitute-ui/src/service-registry-model.js";
+import { projectionPostureSummary } from "../../constitute-ui/src/projection-read-model.js";
 
 function normalizedArray(value) {
   return Array.isArray(value) ? value : [];
@@ -195,15 +196,6 @@ export function normalizeRuntimeRecords(snapshot, options = {}) {
   return Array.from(byKey.values());
 }
 
-function countCoverageStates(coverage) {
-  const counts = {};
-  for (const item of Object.values(normalizeObject(coverage))) {
-    const syncState = String(item?.syncState || "unknown").trim() || "unknown";
-    counts[syncState] = (counts[syncState] || 0) + 1;
-  }
-  return counts;
-}
-
 function latestEntry(entries) {
   return normalizedArray(entries)
     .slice()
@@ -241,20 +233,7 @@ export function prepareSwarmEdgeStatus(snapshot) {
 }
 
 export function prepareProjectionStatus(snapshot) {
-  const coverage = normalizeObject(snapshot?.projectionCoverage);
-  const projections = normalizeObject(snapshot?.projections);
-  const coverageCounts = countCoverageStates(coverage);
-  const projectionCount = Object.keys(projections).length;
-  const coverageCount = Object.keys(coverage).length;
-  const stateLabel = Object.keys(coverageCounts).length === 0
-    ? "none"
-    : Object.entries(coverageCounts).map(([state, count]) => `${state} ${count}`).join(", ");
-  return {
-    projectionCount,
-    coverageCount,
-    coverageCounts,
-    stateLabel,
-  };
+  return projectionPostureSummary(snapshot || {});
 }
 
 export function prepareRuntimeSnapshotModel(snapshot, options = {}) {

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,0 +1,76 @@
+import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
+import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
+
+const ISSUED_AT = 1700000000;
+
+export const gatewaySurfaceAppContract = assertSurfaceAppContract({
+  contractId: "surface-app:constitute-gateway-ui",
+  schemaVersion: SURFACE_APP.SCHEMA_VERSION,
+  appId: "constitute-gateway-ui",
+  appRef: "app:gateway-ui",
+  serviceRef: "service:gateway",
+  surfaceRef: "surface:gateway-ui",
+  version: "0.1.0",
+  displayName: "Gateway",
+  requiredPrimitives: [
+    "runtime.attach",
+    "swarm.directory",
+    "projection.materialization",
+  ],
+  requiredModuleRoles: [
+    SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  ],
+  modules: [
+    {
+      moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.attach", "runtime.intent"],
+      inputs: ["runtime.snapshot"],
+      outputs: ["runtime.intent"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-gateway-ui/runtime-model@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["projection.materialization", "swarm.directory"],
+      inputs: ["runtime.snapshot"],
+      outputs: ["gateway.read-model"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-gateway-ui/product-view@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.posture.render"],
+      inputs: ["gateway.read-model"],
+      outputs: ["user.intent"],
+      issuedAt: ISSUED_AT,
+    },
+  ],
+  projectionSubscriptions: [
+    { projectionId: "swarm.directory", channelId: "swarm.directory" },
+  ],
+  updatePosture: {
+    state: SURFACE_APP.UPDATE_POSTURE.STATIC,
+    checkedAt: ISSUED_AT,
+  },
+  issuedAt: ISSUED_AT,
+});
+
+export const gatewaySurfaceApp = defineSurfaceAppContract(gatewaySurfaceAppContract, {
+  validate: assertSurfaceAppContract,
+});
+
+export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
+  productSurface: "constitute-gateway-ui",
+});

--- a/tests/runtime-model.test.js
+++ b/tests/runtime-model.test.js
@@ -18,12 +18,24 @@ test("runtime model uses retained service catalog records", () => {
     },
     serviceCatalog: {
       updatedAt: 1700000000100,
+      registry: {
+        kind: "service.registry.materialization",
+        registryId: "service-registry:runtime",
+        state: "ready",
+        issuedAt: 1700000000100,
+        claimRefs: ["claim:logging"],
+        entries: [{ memberPk: "gateway-1" }],
+        services: [{
+          service: "logging",
+          servicePk: "logging-1",
+          hostGatewayPk: "gateway-1",
+          health: { status: "online", events: 42, producers: 2, storageStatus: "ok" },
+          surface: { summary: "retained logging surface" },
+        }],
+      },
       services: [{
-        service: "logging",
-        servicePk: "logging-1",
-        hostGatewayPk: "gateway-1",
-        health: { status: "online", events: 42, producers: 2, storageStatus: "ok" },
-        surface: { summary: "retained logging surface" },
+        service: "legacy",
+        servicePk: "legacy-1",
       }],
     },
   };
@@ -31,9 +43,12 @@ test("runtime model uses retained service catalog records", () => {
   const prepared = prepareRuntimeSnapshotModel(snapshot);
 
   assert.equal(prepared.serviceCatalog.serviceCount, 1);
+  assert.equal(prepared.serviceCatalog.source, "serviceRegistry");
+  assert.equal(prepared.serviceCatalog.state, "ready");
+  assert.equal(prepared.serviceCatalog.claimCount, 1);
   assert.equal(prepared.records.some((record) => record.role === "gateway"), true);
   const logging = prepared.records.find((record) => record.service === "logging");
-  assert.equal(logging.__source, "serviceCatalog");
+  assert.equal(logging.__source, "serviceRegistry");
   assert.equal(logging.status, "online");
   assert.equal(logging.facts.health.events, 42);
 });
@@ -94,6 +109,7 @@ test("runtime model surfaces swarm edge queue reject and projection repair statu
     value: "1 revisionGap",
     tone: "warn",
   });
+  assert.equal(rows.find((row) => row.label === "Service catalog").value, "0 services / missing");
   assert.equal(rows.find((row) => row.label === "Projection sync").value, "1 retained / completeEnough 1");
 });
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -15,6 +15,8 @@ test("gateway ui manifest shape stays stable", async () => {
 test("gateway ui uses the current shared runtime worker build", () => {
   const source = readFileSync(resolve(here, "../src/main.js"), "utf8");
   assert.match(source, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);
+  assert.match(source, /from "\.\/surface-app-contract\.js"/);
+  assert.match(source, /attachContext: gatewaySurfaceAttachContext/);
   assert.match(source, /PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID/);
   assert.match(source, /runtimeSharedWorkerName/);
   assert.match(source, /accountRuntimeWorkerScriptUrl\(window\.location\.origin\)/);
@@ -22,6 +24,16 @@ test("gateway ui uses the current shared runtime worker build", () => {
   assert.doesNotMatch(source, /new SharedWorker/);
   assert.doesNotMatch(source, /pendingRuntimeResponses/);
   assert.doesNotMatch(source, /RUNTIME_WORKER_VERSION = Object\.freeze/);
+});
+
+test("gateway ui declares a surface app contract", async () => {
+  const { gatewaySurfaceApp, gatewaySurfaceAttachContext } = await import("../src/surface-app-contract.js");
+  assert.equal(gatewaySurfaceApp.posture.state, "ready");
+  assert.equal(gatewaySurfaceApp.hasRole("runtimeClient"), true);
+  assert.equal(gatewaySurfaceApp.hasRole("projectionModel"), true);
+  assert.equal(gatewaySurfaceApp.hasRole("productView"), true);
+  assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
+  assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
 });
 
 test("gateway network panel consumes shared shell posture", () => {


### PR DESCRIPTION
Declares the Gateway UI surface contract, renders service registry posture, and uses the shared projection posture helper. Gateway UI now consumes shared runtime/gateway read models instead of local projection dialects.\n\nValidation: root docs/convergence/affected/browser/native/check:all passed before branch publication; live surface proof passed against the convergence train.