### PR TITLE
Render gateway runtime posture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
       },
       "devDependencies": {
         "vite": "^6.2.0"
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#ead823d8d8271cfaf19c021c7a675c224d9d4912"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "constitute-gateway-ui",
       "version": "0.1.0",
       "dependencies": {
-        "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+        "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+        "constitute-ui": "github:Aux0x7F/constitute-ui#main"
       },
       "devDependencies": {
         "vite": "^6.2.0"
@@ -855,7 +855,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#ab3f739ffcf53c1e1e594e36bbe458b5233ef822",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
   },
   "devDependencies": {
     "vite": "^6.2.0"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "node --test tests/**/*.test.js"
   },
   "dependencies": {
-    "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+    "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+    "constitute-ui": "github:Aux0x7F/constitute-ui#main"
   },
   "devDependencies": {
     "vite": "^6.2.0"

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ import { RUNTIME_DIAGNOSTIC_OPERATOR_PLANES, attachRuntimeDiagnostics } from "..
 import {
   browserStorageShellContext,
   deriveRuntimeShellState,
-} from "../../constitute-account/runtime-shell-state.js";
+} from "../../constitute-ui/src/runtime-shell-state.js";
 import {
   gatewayRuntimeClientModule,
   gatewaySurfaceAttachContext,

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@ import {
   renderFirstPartyShell,
   setConnectionStateText,
 } from "constitute-ui";
-import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
 import {
   captureActiveFieldState,
   prepareRuntimeSnapshotModel,
@@ -23,7 +22,10 @@ import {
   browserStorageShellContext,
   deriveRuntimeShellState,
 } from "../../constitute-account/runtime-shell-state.js";
-import { gatewaySurfaceAttachContext } from "./surface-app-contract.js";
+import {
+  gatewayRuntimeClientModule,
+  gatewaySurfaceAttachContext,
+} from "./surface-app-contract.js";
 
 const RUNTIME_ATTACH_TIMEOUT_MS = 5_000;
 const RUNTIME_WRITE_TIMEOUT_MS = 10_000;
@@ -401,7 +403,7 @@ function absorbRuntimeSnapshot(snapshot) {
 function attachRuntime() {
   if (typeof SharedWorker === "undefined") return null;
   const debugEnabled = new URLSearchParams(window.location.search || "").get("debug") === "1";
-  runtimeClient = createRuntimeSurfaceClient({
+  runtimeClient = gatewayRuntimeClientModule.createRuntimeSurfaceClient({
     clientId: "gateway-ui",
     surface: "gateway-ui",
     workerUrl: runtimeWorkerUrl(),

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -37,6 +37,15 @@ function normalizeRole(value) {
   return String(value || "").trim().toLowerCase();
 }
 
+function postureState(value, fallback = "unknown") {
+  return String(normalizeObject(value).state || fallback).trim() || fallback;
+}
+
+function postureReason(value) {
+  const posture = normalizeObject(value);
+  return String(posture.cleanupReason || posture.reason || posture.blockedReason || "").trim();
+}
+
 function serviceRecordKey(record) {
   const service = normalizeRole(record?.service || record?.slug || record?.name || "");
   const servicePk = String(record?.devicePk || record?.pk || record?.servicePk || record?.service_pk || "").trim();
@@ -258,6 +267,10 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
   const edge = normalizeObject(prepared?.edge);
   const projection = normalizeObject(prepared?.projection);
   const serviceCatalog = normalizeObject(prepared?.serviceCatalog);
+  const resource = normalizeObject(snapshot?.resource);
+  const retention = normalizeObject(snapshot?.retention);
+  const resourceReason = postureReason(resource);
+  const retentionReason = postureReason(retention);
   return [
     { label: "Runtime build", value: String(snapshot?.buildId || fallbackBuildId), tone: "neutral" },
     { label: "Snapshot age", value: formatAge(snapshot?.updatedAt), tone: "neutral" },
@@ -296,6 +309,16 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
       label: "Projection sync",
       value: `${Number(projection.projectionCount || 0)} retained / ${projection.stateLabel || "none"}`,
       tone: Number(projection.projectionCount || 0) > 0 ? "good" : "warn",
+    },
+    {
+      label: "Resource posture",
+      value: [postureState(resource), resourceReason].filter(Boolean).join(" / "),
+      tone: resource.cleanupAllowed === true ? "good" : "warn",
+    },
+    {
+      label: "Retention posture",
+      value: [postureState(retention), retentionReason].filter(Boolean).join(" / "),
+      tone: retention.releaseRequired === true ? "warn" : "good",
     },
   ];
 }

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,5 +1,15 @@
 import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
 import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
+import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
+import {
+  createSurfaceModuleRegistry,
+  surfaceAppModuleImplementations,
+} from "../../constitute-ui/src/surface-module-registry.js";
+import {
+  prepareRuntimeSnapshotModel,
+  prepareSwarmEdgeStatus,
+  runtimeStatusRows,
+} from "./runtime-model.js";
 
 const ISSUED_AT = 1700000000;
 
@@ -70,6 +80,49 @@ export const gatewaySurfaceAppContract = assertSurfaceAppContract({
 export const gatewaySurfaceApp = defineSurfaceAppContract(gatewaySurfaceAppContract, {
   validate: assertSurfaceAppContract,
 });
+
+export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
+  {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.attach", "runtime.intent"],
+    implementation: Object.freeze({ createRuntimeSurfaceClient }),
+  },
+  {
+    moduleRef: "constitute-gateway-ui/runtime-model@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    version: "0.1.0",
+    primitiveRefs: ["projection.materialization", "swarm.directory"],
+    implementation: Object.freeze({
+      prepareRuntimeSnapshotModel,
+      prepareSwarmEdgeStatus,
+      runtimeStatusRows,
+    }),
+  },
+  {
+    moduleRef: "constitute-gateway-ui/product-view@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.posture.render"],
+    implementation: Object.freeze({ surfaceRef: "constitute-gateway-ui" }),
+  },
+]);
+
+export const gatewaySurfaceModules = surfaceAppModuleImplementations(
+  gatewaySurfaceModuleRegistry,
+  gatewaySurfaceApp,
+);
+
+export const gatewayRuntimeClientModule = gatewaySurfaceModuleRegistry.require(
+  gatewaySurfaceApp,
+  SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+).implementation;
+
+export const gatewayProjectionModelModule = gatewaySurfaceModuleRegistry.require(
+  gatewaySurfaceApp,
+  SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+).implementation;
 
 export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",

--- a/tests/runtime-model.test.js
+++ b/tests/runtime-model.test.js
@@ -81,6 +81,16 @@ test("runtime model surfaces swarm edge queue reject and projection repair statu
         reason: "revisionGap",
       }],
     },
+    resource: {
+      state: "withinBudget",
+      cleanupAllowed: false,
+      cleanupReason: "retention posture must allow release before sweeping",
+    },
+    retention: {
+      state: "releaseRequired",
+      releaseRequired: true,
+      reason: "retention blockers active",
+    },
   };
   const edge = prepareSwarmEdgeStatus(snapshot);
 
@@ -111,6 +121,16 @@ test("runtime model surfaces swarm edge queue reject and projection repair statu
   });
   assert.equal(rows.find((row) => row.label === "Service catalog").value, "0 services / missing");
   assert.equal(rows.find((row) => row.label === "Projection sync").value, "1 retained / completeEnough 1");
+  assert.deepEqual(rows.find((row) => row.label === "Resource posture"), {
+    label: "Resource posture",
+    value: "withinBudget / retention posture must allow release before sweeping",
+    tone: "warn",
+  });
+  assert.deepEqual(rows.find((row) => row.label === "Retention posture"), {
+    label: "Retention posture",
+    value: "releaseRequired / retention blockers active",
+    tone: "warn",
+  });
 });
 
 test("active field state can survive a projection snapshot render", () => {

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -20,18 +20,28 @@ test("gateway ui uses the current shared runtime worker build", () => {
   assert.match(source, /PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID/);
   assert.match(source, /runtimeSharedWorkerName/);
   assert.match(source, /accountRuntimeWorkerScriptUrl\(window\.location\.origin\)/);
-  assert.match(source, /createRuntimeSurfaceClient/);
+  assert.match(source, /gatewayRuntimeClientModule\.createRuntimeSurfaceClient/);
+  assert.doesNotMatch(source, /runtime-surface-client\.js/);
   assert.doesNotMatch(source, /new SharedWorker/);
   assert.doesNotMatch(source, /pendingRuntimeResponses/);
   assert.doesNotMatch(source, /RUNTIME_WORKER_VERSION = Object\.freeze/);
 });
 
 test("gateway ui declares a surface app contract", async () => {
-  const { gatewaySurfaceApp, gatewaySurfaceAttachContext } = await import("../src/surface-app-contract.js");
+  const {
+    gatewayRuntimeClientModule,
+    gatewaySurfaceApp,
+    gatewaySurfaceAttachContext,
+    gatewaySurfaceModuleRegistry,
+    gatewaySurfaceModules,
+  } = await import("../src/surface-app-contract.js");
   assert.equal(gatewaySurfaceApp.posture.state, "ready");
   assert.equal(gatewaySurfaceApp.hasRole("runtimeClient"), true);
   assert.equal(gatewaySurfaceApp.hasRole("projectionModel"), true);
   assert.equal(gatewaySurfaceApp.hasRole("productView"), true);
+  assert.equal(gatewaySurfaceModuleRegistry.kind, "surface.module.registry");
+  assert.equal(gatewaySurfaceModules.state, "ready");
+  assert.equal(typeof gatewayRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
 });


### PR DESCRIPTION
## Summary
- render gateway state from prepared runtime posture
- keep gateway route/repair/resource/retention status as runtime read-model output
- resolve bundled surface modules through the app contract registry

## Tests
- npm test
- npm run build