### PR TITLE
Declare gateway UI service manager posture

### DIFF
--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,5 +1,10 @@
 import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
-import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
+import {
+  defineSurfaceAppContract,
+  surfaceAppBootstrapPosture,
+  surfaceServiceManagerOperationPosture,
+  surfaceServiceManagerProofDigest,
+} from "../../constitute-ui/src/surface-app-contract.js";
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
 import {
   createSurfaceModuleRegistry,
@@ -74,6 +79,23 @@ export const gatewaySurfaceAppContract = assertSurfaceAppContract({
     state: SURFACE_APP.UPDATE_POSTURE.STATIC,
     checkedAt: ISSUED_AT,
   },
+  serviceManagerPosture: {
+    managerId: "manager:manual:gateway-ui",
+    subjectRef: "service:gateway",
+    managerRef: "manager:manual:gateway-ui",
+    state: SURFACE_APP.SERVICE_MANAGER_POSTURE.MANUAL,
+    serviceRefs: ["service:gateway"],
+    capabilityRefs: ["service.manage"],
+    evidenceRefs: ["build:gateway-ui:local"],
+    issuedAt: ISSUED_AT,
+  },
+  secretBoundary: {
+    state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED,
+  },
+  releasePosture: {
+    state: SURFACE_APP.RELEASE_POSTURE.STATIC,
+    evidenceRefs: ["build:gateway-ui:local"],
+  },
   issuedAt: ISSUED_AT,
 });
 
@@ -114,6 +136,22 @@ export const gatewaySurfaceModules = surfaceAppModuleImplementations(
   gatewaySurfaceApp,
 );
 
+export const gatewaySurfaceBootstrapPosture = surfaceAppBootstrapPosture(gatewaySurfaceApp, {
+  issuedAt: ISSUED_AT,
+});
+
+export const gatewayServiceManagerOperationPosture = surfaceServiceManagerOperationPosture(gatewaySurfaceApp, {
+  operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
+  operationId: "operation:gateway-ui:bootstrap-health",
+  requestedAt: ISSUED_AT,
+});
+
+export const gatewayServiceManagerProofDigest = surfaceServiceManagerProofDigest(gatewaySurfaceApp, {
+  operationPosture: gatewayServiceManagerOperationPosture,
+  digestId: "proof-digest:gateway-ui:bootstrap",
+  observedAt: ISSUED_AT,
+});
+
 export const gatewayRuntimeClientModule = gatewaySurfaceModuleRegistry.require(
   gatewaySurfaceApp,
   SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
@@ -126,4 +164,7 @@ export const gatewayProjectionModelModule = gatewaySurfaceModuleRegistry.require
 
 export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",
+  bootstrapPosture: gatewaySurfaceBootstrapPosture,
+  serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
+  serviceManagerProofDigest: gatewayServiceManagerProofDigest,
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -30,8 +30,11 @@ test("gateway ui uses the current shared runtime worker build", () => {
 test("gateway ui declares a surface app contract", async () => {
   const {
     gatewayRuntimeClientModule,
+    gatewayServiceManagerOperationPosture,
+    gatewayServiceManagerProofDigest,
     gatewaySurfaceApp,
     gatewaySurfaceAttachContext,
+    gatewaySurfaceBootstrapPosture,
     gatewaySurfaceModuleRegistry,
     gatewaySurfaceModules,
   } = await import("../src/surface-app-contract.js");
@@ -44,6 +47,11 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(typeof gatewayRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
+  assert.equal(gatewaySurfaceBootstrapPosture.state, "ready");
+  assert.equal(gatewayServiceManagerOperationPosture.kind, "service.manager.operation.posture");
+  assert.equal(gatewayServiceManagerOperationPosture.state, "requested");
+  assert.equal(gatewayServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(gatewaySurfaceAttachContext.serviceManagerOperationPosture, gatewayServiceManagerOperationPosture);
 });
 
 test("gateway network panel consumes shared shell posture", () => {


### PR DESCRIPTION
## Summary
- Declare Gateway UI service-manager posture through the shared surface contract pattern.
- Keep gateway surface state as runtime/gateway projection observation rather than private UI policy.

## Checks
- Root browser smoke passed.
- Root check:all passed locally.