### PR TITLE
Attach gateway surface app contract

### DIFF
--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,6 +1,12 @@
-import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
+import {
+  SURFACE_APP,
+  assertServiceManagerSecretBoundary,
+  assertSurfaceAppBootstrapContract,
+  assertSurfaceAppContract,
+} from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
+  surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
@@ -136,6 +142,18 @@ export const gatewaySurfaceModules = surfaceAppModuleImplementations(
   gatewaySurfaceApp,
 );
 
+export const gatewaySurfaceRunnerPlan = surfaceAppRunnerPlan(gatewaySurfaceApp, {
+  issuedAt: ISSUED_AT,
+});
+
+export const gatewayServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
+  gatewaySurfaceRunnerPlan.secretBoundary,
+);
+
+export const gatewaySurfaceBootstrapContract = assertSurfaceAppBootstrapContract(
+  gatewaySurfaceRunnerPlan.bootstrapContract,
+);
+
 export const gatewaySurfaceBootstrapPosture = surfaceAppBootstrapPosture(gatewaySurfaceApp, {
   issuedAt: ISSUED_AT,
 });
@@ -164,6 +182,9 @@ export const gatewayProjectionModelModule = gatewaySurfaceModuleRegistry.require
 
 export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",
+  runnerPlan: gatewaySurfaceRunnerPlan,
+  bootstrapContract: gatewaySurfaceBootstrapContract,
+  serviceManagerSecretBoundary: gatewayServiceManagerSecretBoundary,
   bootstrapPosture: gatewaySurfaceBootstrapPosture,
   serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
   serviceManagerProofDigest: gatewayServiceManagerProofDigest,

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -32,11 +32,14 @@ test("gateway ui declares a surface app contract", async () => {
     gatewayRuntimeClientModule,
     gatewayServiceManagerOperationPosture,
     gatewayServiceManagerProofDigest,
+    gatewayServiceManagerSecretBoundary,
     gatewaySurfaceApp,
     gatewaySurfaceAttachContext,
+    gatewaySurfaceBootstrapContract,
     gatewaySurfaceBootstrapPosture,
     gatewaySurfaceModuleRegistry,
     gatewaySurfaceModules,
+    gatewaySurfaceRunnerPlan,
   } = await import("../src/surface-app-contract.js");
   assert.equal(gatewaySurfaceApp.posture.state, "ready");
   assert.equal(gatewaySurfaceApp.hasRole("runtimeClient"), true);
@@ -48,9 +51,17 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
   assert.equal(gatewaySurfaceBootstrapPosture.state, "ready");
+  assert.equal(gatewaySurfaceRunnerPlan.kind, "surface.app.runner.plan");
+  assert.equal(gatewaySurfaceRunnerPlan.state, "ready");
+  assert.equal(gatewaySurfaceBootstrapContract.kind, "surface.app.bootstrap.contract");
+  assert.equal(gatewaySurfaceBootstrapContract.state, "ready");
+  assert.equal(gatewayServiceManagerSecretBoundary.kind, "service.manager.secretBoundary");
+  assert.equal(gatewayServiceManagerSecretBoundary.state, "notRequired");
   assert.equal(gatewayServiceManagerOperationPosture.kind, "service.manager.operation.posture");
   assert.equal(gatewayServiceManagerOperationPosture.state, "requested");
   assert.equal(gatewayServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(gatewaySurfaceAttachContext.runnerPlan, gatewaySurfaceRunnerPlan);
+  assert.equal(gatewaySurfaceAttachContext.bootstrapContract, gatewaySurfaceBootstrapContract);
   assert.equal(gatewaySurfaceAttachContext.serviceManagerOperationPosture, gatewayServiceManagerOperationPosture);
 });
 


### PR DESCRIPTION
## Summary
- declare the Gateway UI as a surface app contract
- attach shared module role posture to the product surface
- keep gateway product state derived from runtime projections

## Tests
- gateway UI tests and build
- root convergence and affected checks
- browser smoke and 10-minute stream collection