### PR TITLE
Bind Gateway UI to shared surface posture

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -433,8 +433,15 @@ function attachRuntime() {
     onAttachTimeout: () => {
       if (!bootSplashDismissed) dismissBootSplash();
     },
-    onAttachError: (error) => {
-      console.warn("[gateway-ui] runtime attach failed", error);
+    onAttachPosture: (posture) => {
+      if (!posture || posture.severity === "info") return;
+      console.info("[gateway-ui] runtime attach fallback", {
+        state: posture.state,
+        severity: posture.severity,
+        reason: posture.reason,
+      });
+    },
+    onAttachError: () => {
       window.setTimeout(() => dismissBootSplash(), 350);
     },
   });

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -14,7 +14,7 @@ import {
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
 import {
   createSurfaceModuleRegistry,
-  surfaceAppModuleImplementations,
+  surfaceAppModuleBindings,
 } from "../../constitute-ui/src/surface-module-registry.js";
 import {
   prepareRuntimeSnapshotModel,
@@ -137,9 +137,14 @@ export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
   },
 ]);
 
-export const gatewaySurfaceModules = surfaceAppModuleImplementations(
+export const gatewaySurfaceModules = surfaceAppModuleBindings(
   gatewaySurfaceModuleRegistry,
   gatewaySurfaceApp,
+  {
+    runtimeClient: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    projectionModel: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    productView: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  },
 );
 
 export const gatewaySurfaceRunnerPlan = surfaceAppRunnerPlan(gatewaySurfaceApp, {
@@ -170,15 +175,9 @@ export const gatewayServiceManagerProofDigest = surfaceServiceManagerProofDigest
   observedAt: ISSUED_AT,
 });
 
-export const gatewayRuntimeClientModule = gatewaySurfaceModuleRegistry.require(
-  gatewaySurfaceApp,
-  SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
-).implementation;
+export const gatewayRuntimeClientModule = gatewaySurfaceModules.byKey.runtimeClient.implementation;
 
-export const gatewayProjectionModelModule = gatewaySurfaceModuleRegistry.require(
-  gatewaySurfaceApp,
-  SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
-).implementation;
+export const gatewayProjectionModelModule = gatewaySurfaceModules.byKey.projectionModel.implementation;
 
 export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,26 +1,15 @@
 import {
   SURFACE_APP,
-  assertServiceManagerSecretBoundary,
-  assertSurfaceAppBootstrapContract,
-  assertSurfaceAppInstancePosture,
   assertSurfaceAppManifest,
-  assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppContract,
-  assertSurfaceAppRunnerPlan,
 } from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
-  surfaceAppBootstrapPosture,
-  surfaceAppInstancePosture,
-  surfaceAppRuntimeSelectionPosture,
-  surfaceAppRunnerPlan,
-  surfaceServiceManagerOperationPosture,
-  surfaceServiceManagerProofDigest,
 } from "../../constitute-ui/src/surface-app-contract.js";
+import { surfaceAppSelectionReadModel } from "../../constitute-ui/src/surface-selection-read-model.js";
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
 import {
   createSurfaceModuleRegistry,
-  surfaceAppModuleBindings,
 } from "../../constitute-ui/src/surface-module-registry.js";
 import {
   prepareRuntimeSnapshotModel,
@@ -172,15 +161,6 @@ export const gatewaySurfaceAppManifest = assertSurfaceAppManifest({
   issuedAt: ISSUED_AT,
 });
 
-export const gatewaySurfaceRuntimeSelectionPosture = assertSurfaceAppRuntimeSelectionPosture(surfaceAppRuntimeSelectionPosture(
-  gatewaySurfaceAppManifest,
-  [gatewaySurfaceApp],
-  {
-    runtimeVersion: "0.1.0",
-    issuedAt: ISSUED_AT,
-  },
-));
-
 export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
@@ -209,67 +189,41 @@ export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
   },
 ]);
 
-export const gatewaySurfaceModules = surfaceAppModuleBindings(
-  gatewaySurfaceModuleRegistry,
-  gatewaySurfaceRuntimeSelectionPosture,
-  {
+export const gatewaySurfaceSelectionReadModel = surfaceAppSelectionReadModel({
+  surfaceApp: gatewaySurfaceApp,
+  manifest: gatewaySurfaceAppManifest,
+  moduleRegistry: gatewaySurfaceModuleRegistry,
+  moduleRoles: {
     runtimeClient: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
     projectionModel: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
     productView: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
   },
-);
-
-export const gatewaySurfaceRunnerPlan = assertSurfaceAppRunnerPlan(surfaceAppRunnerPlan(gatewaySurfaceApp, {
+  productSurface: "constitute-gateway-ui",
+  runtimeVersion: "0.1.0",
   issuedAt: ISSUED_AT,
-}));
-
-export const gatewayServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
-  gatewaySurfaceRunnerPlan.secretBoundary,
-);
-
-export const gatewaySurfaceBootstrapContract = assertSurfaceAppBootstrapContract(
-  gatewaySurfaceRunnerPlan.bootstrapContract,
-);
-
-export const gatewaySurfaceBootstrapPosture = surfaceAppBootstrapPosture(gatewaySurfaceApp, {
-  issuedAt: ISSUED_AT,
+  serviceManagerOperationOptions: {
+    operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
+    operationId: "operation:gateway-ui:bootstrap-health",
+    requestedAt: ISSUED_AT,
+  },
+  serviceManagerProofDigestOptions: {
+    digestId: "proof-digest:gateway-ui:bootstrap",
+    observedAt: ISSUED_AT,
+  },
 });
 
-export const gatewayServiceManagerOperationPosture = surfaceServiceManagerOperationPosture(gatewaySurfaceApp, {
-  operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
-  operationId: "operation:gateway-ui:bootstrap-health",
-  requestedAt: ISSUED_AT,
-});
-
-export const gatewayServiceManagerProofDigest = surfaceServiceManagerProofDigest(gatewaySurfaceApp, {
-  operationPosture: gatewayServiceManagerOperationPosture,
-  digestId: "proof-digest:gateway-ui:bootstrap",
-  observedAt: ISSUED_AT,
-});
-
-export const gatewaySurfaceAppInstancePosture = assertSurfaceAppInstancePosture(surfaceAppInstancePosture(gatewaySurfaceApp, {
-  runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
-  moduleBindings: gatewaySurfaceModules,
-  runnerPlan: gatewaySurfaceRunnerPlan,
-  bootstrapContract: gatewaySurfaceBootstrapContract,
-  bootstrapPosture: gatewaySurfaceBootstrapPosture,
-  serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
-  serviceManagerProofDigest: gatewayServiceManagerProofDigest,
-  issuedAt: ISSUED_AT,
-}));
+export const gatewaySurfaceRuntimeSelectionPosture = gatewaySurfaceSelectionReadModel.runtimeSelectionPosture;
+export const gatewaySurfaceModules = gatewaySurfaceSelectionReadModel.moduleBindings;
+export const gatewaySurfaceRunnerPlan = gatewaySurfaceSelectionReadModel.runnerPlan;
+export const gatewayServiceManagerSecretBoundary = gatewaySurfaceSelectionReadModel.serviceManagerSecretBoundary;
+export const gatewaySurfaceBootstrapContract = gatewaySurfaceSelectionReadModel.bootstrapContract;
+export const gatewaySurfaceBootstrapPosture = gatewaySurfaceSelectionReadModel.bootstrapPosture;
+export const gatewayServiceManagerOperationPosture = gatewaySurfaceSelectionReadModel.serviceManagerOperationPosture;
+export const gatewayServiceManagerProofDigest = gatewaySurfaceSelectionReadModel.serviceManagerProofDigest;
+export const gatewaySurfaceAppInstancePosture = gatewaySurfaceSelectionReadModel.appInstancePosture;
 
 export const gatewayRuntimeClientModule = gatewaySurfaceModules.byKey.runtimeClient.implementation;
 
 export const gatewayProjectionModelModule = gatewaySurfaceModules.byKey.projectionModel.implementation;
 
-export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
-  productSurface: "constitute-gateway-ui",
-  runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
-  runnerPlan: gatewaySurfaceRunnerPlan,
-  appInstancePosture: gatewaySurfaceAppInstancePosture,
-  bootstrapContract: gatewaySurfaceBootstrapContract,
-  serviceManagerSecretBoundary: gatewayServiceManagerSecretBoundary,
-  bootstrapPosture: gatewaySurfaceBootstrapPosture,
-  serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
-  serviceManagerProofDigest: gatewayServiceManagerProofDigest,
-});
+export const gatewaySurfaceAttachContext = gatewaySurfaceSelectionReadModel.attachContext;

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -7,9 +7,10 @@ import {
 } from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
-  surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
+  surfaceAppInstancePosture,
   surfaceAppRuntimeSelectionPosture,
+  surfaceAppRunnerPlan,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
 } from "../../constitute-ui/src/surface-app-contract.js";
@@ -243,6 +244,17 @@ export const gatewayServiceManagerProofDigest = surfaceServiceManagerProofDigest
   observedAt: ISSUED_AT,
 });
 
+export const gatewaySurfaceAppInstancePosture = surfaceAppInstancePosture(gatewaySurfaceApp, {
+  runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
+  moduleBindings: gatewaySurfaceModules,
+  runnerPlan: gatewaySurfaceRunnerPlan,
+  bootstrapContract: gatewaySurfaceBootstrapContract,
+  bootstrapPosture: gatewaySurfaceBootstrapPosture,
+  serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
+  serviceManagerProofDigest: gatewayServiceManagerProofDigest,
+  issuedAt: ISSUED_AT,
+});
+
 export const gatewayRuntimeClientModule = gatewaySurfaceModules.byKey.runtimeClient.implementation;
 
 export const gatewayProjectionModelModule = gatewaySurfaceModules.byKey.projectionModel.implementation;
@@ -251,6 +263,7 @@ export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",
   runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
   runnerPlan: gatewaySurfaceRunnerPlan,
+  appInstancePosture: gatewaySurfaceAppInstancePosture,
   bootstrapContract: gatewaySurfaceBootstrapContract,
   serviceManagerSecretBoundary: gatewayServiceManagerSecretBoundary,
   bootstrapPosture: gatewaySurfaceBootstrapPosture,

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -2,8 +2,11 @@ import {
   SURFACE_APP,
   assertServiceManagerSecretBoundary,
   assertSurfaceAppBootstrapContract,
+  assertSurfaceAppInstancePosture,
   assertSurfaceAppManifest,
+  assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppContract,
+  assertSurfaceAppRunnerPlan,
 } from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
@@ -169,14 +172,14 @@ export const gatewaySurfaceAppManifest = assertSurfaceAppManifest({
   issuedAt: ISSUED_AT,
 });
 
-export const gatewaySurfaceRuntimeSelectionPosture = surfaceAppRuntimeSelectionPosture(
+export const gatewaySurfaceRuntimeSelectionPosture = assertSurfaceAppRuntimeSelectionPosture(surfaceAppRuntimeSelectionPosture(
   gatewaySurfaceAppManifest,
   [gatewaySurfaceApp],
   {
     runtimeVersion: "0.1.0",
     issuedAt: ISSUED_AT,
   },
-);
+));
 
 export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
@@ -216,9 +219,9 @@ export const gatewaySurfaceModules = surfaceAppModuleBindings(
   },
 );
 
-export const gatewaySurfaceRunnerPlan = surfaceAppRunnerPlan(gatewaySurfaceApp, {
+export const gatewaySurfaceRunnerPlan = assertSurfaceAppRunnerPlan(surfaceAppRunnerPlan(gatewaySurfaceApp, {
   issuedAt: ISSUED_AT,
-});
+}));
 
 export const gatewayServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
   gatewaySurfaceRunnerPlan.secretBoundary,
@@ -244,7 +247,7 @@ export const gatewayServiceManagerProofDigest = surfaceServiceManagerProofDigest
   observedAt: ISSUED_AT,
 });
 
-export const gatewaySurfaceAppInstancePosture = surfaceAppInstancePosture(gatewaySurfaceApp, {
+export const gatewaySurfaceAppInstancePosture = assertSurfaceAppInstancePosture(surfaceAppInstancePosture(gatewaySurfaceApp, {
   runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
   moduleBindings: gatewaySurfaceModules,
   runnerPlan: gatewaySurfaceRunnerPlan,
@@ -253,7 +256,7 @@ export const gatewaySurfaceAppInstancePosture = surfaceAppInstancePosture(gatewa
   serviceManagerOperationPosture: gatewayServiceManagerOperationPosture,
   serviceManagerProofDigest: gatewayServiceManagerProofDigest,
   issuedAt: ISSUED_AT,
-});
+}));
 
 export const gatewayRuntimeClientModule = gatewaySurfaceModules.byKey.runtimeClient.implementation;
 

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -2,12 +2,14 @@ import {
   SURFACE_APP,
   assertServiceManagerSecretBoundary,
   assertSurfaceAppBootstrapContract,
+  assertSurfaceAppManifest,
   assertSurfaceAppContract,
 } from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
   surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
+  surfaceAppRuntimeSelectionPosture,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
 } from "../../constitute-ui/src/surface-app-contract.js";
@@ -109,6 +111,72 @@ export const gatewaySurfaceApp = defineSurfaceAppContract(gatewaySurfaceAppContr
   validate: assertSurfaceAppContract,
 });
 
+export const gatewaySurfaceAppManifest = assertSurfaceAppManifest({
+  kind: "surface.app.manifest",
+  manifestId: "manifest:gateway-ui",
+  appId: "constitute-gateway-ui",
+  state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+  currentAppContractRef: "app:gateway-ui",
+  currentVersion: "0.1.0",
+  defaultSourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+  requiredModuleRoles: [
+    SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  ],
+  bundledSourceRefs: ["bundle:gateway-ui@0.1.0"],
+  compatibilityWindow: {
+    minVersion: "0.1.0",
+    maxVersion: "0.1.x",
+    protocolRef: "protocol:surface-app:v1",
+  },
+  versions: [
+    {
+      appContractRef: "app:gateway-ui",
+      version: "0.1.0",
+      state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+      sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      requiredModuleRoles: [
+        SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+        SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+        SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+      ],
+      compatibilityWindow: {
+        minVersion: "0.1.0",
+        maxVersion: "0.1.x",
+        protocolRef: "protocol:surface-app:v1",
+      },
+      bundledSourceRefs: ["bundle:gateway-ui@0.1.0"],
+      grantRefs: ["grant:app:gateway-ui:run"],
+      runnerRequirementRefs: ["runner:req:gateway-ui"],
+      serviceManagerRequirementRefs: ["service-manager:req:gateway-ui"],
+      compatibilityRefs: ["protocol:surface-app:v1"],
+      bootstrapContractRef: "bootstrap-contract:app:gateway-ui",
+      releaseContractRef: "release:gateway-ui:local",
+      issuedAt: ISSUED_AT,
+    },
+  ],
+  appContractRefs: ["app:gateway-ui"],
+  grantRefs: ["grant:app:gateway-ui:run"],
+  runnerRequirementRefs: ["runner:req:gateway-ui"],
+  serviceManagerRequirementRefs: ["service-manager:req:gateway-ui"],
+  compatibilityRefs: ["protocol:surface-app:v1"],
+  bootstrapContractRefs: ["bootstrap-contract:app:gateway-ui"],
+  releaseContractRefs: ["release:gateway-ui:local"],
+  authorityRefs: ["authority:gateway-ui:local"],
+  evidenceRefs: ["build:gateway-ui:local"],
+  issuedAt: ISSUED_AT,
+});
+
+export const gatewaySurfaceRuntimeSelectionPosture = surfaceAppRuntimeSelectionPosture(
+  gatewaySurfaceAppManifest,
+  [gatewaySurfaceApp],
+  {
+    runtimeVersion: "0.1.0",
+    issuedAt: ISSUED_AT,
+  },
+);
+
 export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
   {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
@@ -139,7 +207,7 @@ export const gatewaySurfaceModuleRegistry = createSurfaceModuleRegistry([
 
 export const gatewaySurfaceModules = surfaceAppModuleBindings(
   gatewaySurfaceModuleRegistry,
-  gatewaySurfaceApp,
+  gatewaySurfaceRuntimeSelectionPosture,
   {
     runtimeClient: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
     projectionModel: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
@@ -181,6 +249,7 @@ export const gatewayProjectionModelModule = gatewaySurfaceModules.byKey.projecti
 
 export const gatewaySurfaceAttachContext = gatewaySurfaceApp.attachContext({
   productSurface: "constitute-gateway-ui",
+  runtimeSelectionPosture: gatewaySurfaceRuntimeSelectionPosture,
   runnerPlan: gatewaySurfaceRunnerPlan,
   bootstrapContract: gatewaySurfaceBootstrapContract,
   serviceManagerSecretBoundary: gatewayServiceManagerSecretBoundary,

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -34,6 +34,7 @@ test("gateway ui declares a surface app contract", async () => {
     gatewayServiceManagerProofDigest,
     gatewayServiceManagerSecretBoundary,
     gatewaySurfaceApp,
+    gatewaySurfaceRuntimeSelectionPosture,
     gatewaySurfaceAttachContext,
     gatewaySurfaceBootstrapContract,
     gatewaySurfaceBootstrapPosture,
@@ -47,6 +48,8 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewaySurfaceApp.hasRole("productView"), true);
   assert.equal(gatewaySurfaceModuleRegistry.kind, "surface.module.registry");
   assert.equal(gatewaySurfaceModules.state, "ready");
+  assert.equal(gatewaySurfaceRuntimeSelectionPosture.kind, "surface.app.runtime.selection.posture");
+  assert.equal(gatewaySurfaceRuntimeSelectionPosture.state, "ready");
   assert.equal(typeof gatewayRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
@@ -60,6 +63,7 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewayServiceManagerOperationPosture.kind, "service.manager.operation.posture");
   assert.equal(gatewayServiceManagerOperationPosture.state, "requested");
   assert.equal(gatewayServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(gatewaySurfaceAttachContext.runtimeSelectionPosture, gatewaySurfaceRuntimeSelectionPosture);
   assert.equal(gatewaySurfaceAttachContext.runnerPlan, gatewaySurfaceRunnerPlan);
   assert.equal(gatewaySurfaceAttachContext.bootstrapContract, gatewaySurfaceBootstrapContract);
   assert.equal(gatewaySurfaceAttachContext.serviceManagerOperationPosture, gatewayServiceManagerOperationPosture);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -34,6 +34,7 @@ test("gateway ui declares a surface app contract", async () => {
     gatewayServiceManagerProofDigest,
     gatewayServiceManagerSecretBoundary,
     gatewaySurfaceApp,
+    gatewaySurfaceAppInstancePosture,
     gatewaySurfaceRuntimeSelectionPosture,
     gatewaySurfaceAttachContext,
     gatewaySurfaceBootstrapContract,
@@ -53,6 +54,9 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(typeof gatewayRuntimeClientModule.createRuntimeSurfaceClient, "function");
   assert.equal(gatewaySurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(gatewaySurfaceAttachContext.appId, "constitute-gateway-ui");
+  assert.equal(gatewaySurfaceAppInstancePosture.kind, "surface.app.instance.posture");
+  assert.equal(gatewaySurfaceAppInstancePosture.state, "ready");
+  assert.equal(gatewaySurfaceAppInstancePosture.appId, "constitute-gateway-ui");
   assert.equal(gatewaySurfaceBootstrapPosture.state, "ready");
   assert.equal(gatewaySurfaceRunnerPlan.kind, "surface.app.runner.plan");
   assert.equal(gatewaySurfaceRunnerPlan.state, "ready");
@@ -64,6 +68,7 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewayServiceManagerOperationPosture.state, "requested");
   assert.equal(gatewayServiceManagerProofDigest.kind, "service.manager.proof.digest");
   assert.equal(gatewaySurfaceAttachContext.runtimeSelectionPosture, gatewaySurfaceRuntimeSelectionPosture);
+  assert.equal(gatewaySurfaceAttachContext.appInstancePosture, gatewaySurfaceAppInstancePosture);
   assert.equal(gatewaySurfaceAttachContext.runnerPlan, gatewaySurfaceRunnerPlan);
   assert.equal(gatewaySurfaceAttachContext.bootstrapContract, gatewaySurfaceBootstrapContract);
   assert.equal(gatewaySurfaceAttachContext.serviceManagerOperationPosture, gatewayServiceManagerOperationPosture);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -42,6 +42,7 @@ test("gateway ui declares a surface app contract", async () => {
     gatewaySurfaceModuleRegistry,
     gatewaySurfaceModules,
     gatewaySurfaceRunnerPlan,
+    gatewaySurfaceSelectionReadModel,
   } = await import("../src/surface-app-contract.js");
   assert.equal(gatewaySurfaceApp.posture.state, "ready");
   assert.equal(gatewaySurfaceApp.hasRole("runtimeClient"), true);
@@ -49,6 +50,8 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewaySurfaceApp.hasRole("productView"), true);
   assert.equal(gatewaySurfaceModuleRegistry.kind, "surface.module.registry");
   assert.equal(gatewaySurfaceModules.state, "ready");
+  assert.equal(gatewaySurfaceSelectionReadModel.kind, "surface.app.selection.readModel");
+  assert.equal(gatewaySurfaceSelectionReadModel.state, "ready");
   assert.equal(gatewaySurfaceRuntimeSelectionPosture.kind, "surface.app.runtime.selection.posture");
   assert.equal(gatewaySurfaceRuntimeSelectionPosture.state, "ready");
   assert.equal(typeof gatewayRuntimeClientModule.createRuntimeSurfaceClient, "function");
@@ -68,6 +71,7 @@ test("gateway ui declares a surface app contract", async () => {
   assert.equal(gatewayServiceManagerOperationPosture.state, "requested");
   assert.equal(gatewayServiceManagerProofDigest.kind, "service.manager.proof.digest");
   assert.equal(gatewaySurfaceAttachContext.runtimeSelectionPosture, gatewaySurfaceRuntimeSelectionPosture);
+  assert.equal(gatewaySurfaceSelectionReadModel.attachContext, gatewaySurfaceAttachContext);
   assert.equal(gatewaySurfaceAttachContext.appInstancePosture, gatewaySurfaceAppInstancePosture);
   assert.equal(gatewaySurfaceAttachContext.runnerPlan, gatewaySurfaceRunnerPlan);
   assert.equal(gatewaySurfaceAttachContext.bootstrapContract, gatewaySurfaceBootstrapContract);


### PR DESCRIPTION
## Summary
- consume shared surface app module and adapter posture in Gateway UI
- keep hosted service truth rendered from runtime/gateway projections instead of local UI inference

## Proof
- Gateway UI build passes through root all check
- root docs, convergence, affected, browser, native, and all checks pass locally
- authenticated surface landscape proof passed