### PR TITLE
Use packaged surface helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,7 +855,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#d75e53e8b31674b34e8cd57621c1fb508d70a1eb",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -864,7 +864,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#52759e1325d4151712ddc13ec27516bf72066462"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ import { RUNTIME_DIAGNOSTIC_OPERATOR_PLANES, attachRuntimeDiagnostics } from "..
 import {
   browserStorageShellContext,
   deriveRuntimeShellState,
-} from "../../constitute-ui/src/runtime-shell-state.js";
+} from "constitute-ui/runtime-shell-state";
 import {
   gatewayRuntimeClientModule,
   gatewaySurfaceAttachContext,

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -1,5 +1,7 @@
-import { preparedServiceRegistry } from "../../constitute-ui/src/service-registry-model.js";
-import { projectionPostureSummary } from "../../constitute-ui/src/projection-read-model.js";
+import {
+  preparedServiceRegistry,
+  projectionPostureSummary,
+} from "constitute-ui";
 
 function normalizedArray(value) {
   return Array.isArray(value) ? value : [];

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -2,15 +2,15 @@ import {
   SURFACE_APP,
   assertSurfaceAppManifest,
   assertSurfaceAppContract,
-} from "../../constitute-protocol/src/index.js";
+} from "constitute-protocol";
 import {
   defineSurfaceAppContract,
-} from "../../constitute-ui/src/surface-app-contract.js";
-import { surfaceAppSelectionReadModel } from "../../constitute-ui/src/surface-selection-read-model.js";
-import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
+} from "constitute-ui/surface-app-contract";
+import { surfaceAppSelectionReadModel } from "constitute-ui/surface-selection-read-model";
+import { createRuntimeSurfaceClient } from "constitute-ui/runtime-surface-client";
 import {
   createSurfaceModuleRegistry,
-} from "../../constitute-ui/src/surface-module-registry.js";
+} from "constitute-ui/surface-module-registry";
 import {
   prepareRuntimeSnapshotModel,
   prepareSwarmEdgeStatus,


### PR DESCRIPTION
## Summary
- Uses packaged surface helpers for runtime binding and posture consumption.
- Keeps Gateway UI focused on gateway/runtime projection truth instead of local helper dialects.

## Proof
- Package build passed locally.
- Root docs, convergence, affected, browser, native, and all checks passed in the full train.
- Browser landscape proof passed across Account, Gateway UI, Logging UI, NVR UI, and Security.