### PR TITLE
Adopt gateway service read model

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
   prepareRuntimeSnapshotModel,
   restoreActiveFieldState,
   runtimeStatusRows,
+  serviceLaunchPosture,
 } from "./runtime-model.js";
 import {
   PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID,
@@ -566,6 +567,7 @@ function hostedNvrForGateway(gatewayRecord, records) {
   return {
     ...embedded,
     __scope: gatewayRecord.__scope,
+    __source: embedded.__source || gatewayRecord.__source || "runtimeBaseline",
     hostGatewayPk: String(embedded.hostGatewayPk || embedded.host_gateway_pk || gatewayPk).trim(),
   };
 }
@@ -632,6 +634,7 @@ function collectInstalledServices(records) {
       service,
       hostGatewayPk,
       __scope: record.__scope || gatewayRecord?.__scope,
+      __source: record.__source || gatewayRecord?.__source || "runtimeBaseline",
       __hostGatewayLabel: gatewayRecord ? gatewayTitle(gatewayRecord) : "",
     };
     byKey.set(key, mergeServiceRecord(byKey.get(key), normalized));
@@ -742,6 +745,7 @@ function renderGatewayList(records) {
     `;
     const actions = document.createElement("div");
     actions.className = "gatewayActionStrip";
+    const nvrLaunch = nvrRecord ? serviceLaunchPosture(nvrRecord) : { state: "blocked", reason: "NVR service is not projected for this gateway yet." };
     const zoneInput = document.createElement("input");
     zoneInput.type = "text";
     zoneInput.className = "gatewayInlineInput";
@@ -758,8 +762,8 @@ function renderGatewayList(records) {
         hostGatewayPk: gatewayPk,
         service: "nvr",
       }, {});
-    }, !nvrRecord);
-    if (!nvrRecord) openNvrButton.title = "NVR service is not projected for this gateway yet.";
+    }, !nvrRecord || nvrLaunch.state !== "ready");
+    if (!nvrRecord || nvrLaunch.state !== "ready") openNvrButton.title = nvrLaunch.reason || "NVR service is not actionable yet.";
     actions.appendChild(openNvrButton);
 
     if (!nvrRecord && !gatewayReportsNvrService(record)) {
@@ -794,6 +798,8 @@ function renderServiceList(records) {
     const servicePk = String(record?.devicePk || record?.pk || "").trim();
     const service = serviceSlug(record);
     const status = serviceStatus(record);
+    const launch = serviceLaunchPosture(record);
+    const launchBlocked = launch.state !== "ready";
     const facts = record?.facts && typeof record.facts === "object" ? record.facts : {};
     const health = facts?.health && typeof facts.health === "object" ? facts.health : {};
     const factRows = service === "storage"
@@ -826,6 +832,7 @@ function renderServiceList(records) {
             <div>status <span class="gatewayStatusTone-${escapeHtml(toneForLabel(status))}">${escapeHtml(status)}</span></div>
             <div>host gateway ${escapeHtml(record.__hostGatewayLabel || shortPk(record?.hostGatewayPk || record?.host_gateway_pk || ""))}</div>
             <div>host fabric ${escapeHtml(record.hostFabric?.label || "missing")}</div>
+            <div>launch ${escapeHtml(launch.label || launch.state || "unknown")}</div>
             <div>source ${escapeHtml(record.__source === "serviceRegistry" ? "service registry" : record.__source === "serviceCatalog" ? "runtime catalog" : "runtime baseline")}</div>
             <div>freshness ${escapeHtml(freshnessLabel(record))}</div>
             ${factRows.map((fact) => `<div>${escapeHtml(fact)}</div>`).join("")}
@@ -839,14 +846,14 @@ function renderServiceList(records) {
     if (service === "nvr") {
       actions.appendChild(actionButton("Open Security Cameras", () => {
         void openSecurityCameras(record, {});
-      }, !servicePk));
+      }, !servicePk || launchBlocked));
       actions.appendChild(actionButton("Camera Settings", () => {
         void openSecurityCameras(record, { activity: "settings" });
-      }, !servicePk));
+      }, !servicePk || launchBlocked));
     } else if (service === "logging") {
       actions.appendChild(actionButton("Open Logging", () => {
         void openLogging(record);
-      }, !servicePk));
+      }, !servicePk || launchBlocked));
     }
     if (actions.childElementCount > 0) row.appendChild(actions);
     serviceListEl.appendChild(row);
@@ -994,6 +1001,11 @@ async function openSecurityCameras(record, opts = {}) {
     addNotification("warn", "Runtime unavailable", "Open constitute-account to hydrate the shared runtime first.");
     return;
   }
+  const launch = serviceLaunchPosture(record);
+  if (launch.state !== "ready") {
+    addNotification("warn", "Service not actionable", launch.reason || "Service registry posture is not ready.");
+    return;
+  }
   const url = buildManagedSurfaceUrl("constitute-nvr-ui", opts);
   window.open(url, "_blank", "noopener,noreferrer");
   const label = String(record?.label || record?.deviceLabel || record?.displayName || "runtime directory").trim();
@@ -1003,6 +1015,11 @@ async function openSecurityCameras(record, opts = {}) {
 async function openLogging(record) {
   if (!runtimeReady) {
     addNotification("warn", "Runtime unavailable", "Open constitute-account to hydrate the shared runtime first.");
+    return;
+  }
+  const launch = serviceLaunchPosture(record);
+  if (launch.state !== "ready") {
+    addNotification("warn", "Service not actionable", launch.reason || "Service registry posture is not ready.");
     return;
   }
   const url = buildManagedSurfaceUrl("constitute-logging-ui");

--- a/src/main.js
+++ b/src/main.js
@@ -825,6 +825,7 @@ function renderServiceList(records) {
             <div>service ${escapeHtml(service || "unknown")}</div>
             <div>status <span class="gatewayStatusTone-${escapeHtml(toneForLabel(status))}">${escapeHtml(status)}</span></div>
             <div>host gateway ${escapeHtml(record.__hostGatewayLabel || shortPk(record?.hostGatewayPk || record?.host_gateway_pk || ""))}</div>
+            <div>host fabric ${escapeHtml(record.hostFabric?.label || "missing")}</div>
             <div>source ${escapeHtml(record.__source === "serviceRegistry" ? "service registry" : record.__source === "serviceCatalog" ? "runtime catalog" : "runtime baseline")}</div>
             <div>freshness ${escapeHtml(freshnessLabel(record))}</div>
             ${factRows.map((fact) => `<div>${escapeHtml(fact)}</div>`).join("")}

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -1,5 +1,7 @@
 import {
   deriveRuntimeMaterializationPosture,
+  prepareServiceHostFabricPosture,
+  prepareServiceLaunchPosture,
   prepareRuntimeHostFabricPosture,
   prepareRuntimeTargetPosture,
   preparedServiceRegistry,
@@ -51,61 +53,12 @@ function postureReason(value) {
   return String(posture.cleanupReason || posture.reason || posture.blockedReason || "").trim();
 }
 
-function hostFabricPosture(value) {
-  const fabric = normalizeObject(value);
-  if (!Object.keys(fabric).length) {
-    return { state: "missing", blockedReasons: [], label: "missing" };
-  }
-  const state = String(fabric.state || fabric.fulfillmentPlan?.state || fabric.lifecyclePlan?.state || "unknown").trim() || "unknown";
-  const blockedReasons = normalizedArray(fabric.blockedReasons).map((reason) => String(reason || "").trim()).filter(Boolean);
-  const handoffRef = String(fabric.associationHandoffRef || "").trim();
-  return {
-    state,
-    blockedReasons,
-    handoffRef,
-    label: [
-      state,
-      blockedReasons.length ? `blocked ${blockedReasons.slice(0, 2).join(", ")}` : "",
-      handoffRef ? `handoff ${shortRef(handoffRef)}` : "",
-    ].filter(Boolean).join(" / "),
-  };
-}
-
 export function serviceLaunchPosture(record) {
-  const source = String(record?.__source || "").trim();
-  const fabric = normalizeObject(record?.hostFabric);
-  const legacyFallback = normalizeObject(record?.legacyPathFallback || record?.legacy_path_fallback);
-  if (Object.keys(legacyFallback).length > 0) {
-    const reason = String(legacyFallback.reason || "legacy path fallback is quarantined").trim();
-    return {
-      state: "blocked",
-      reason,
-      label: `blocked / ${reason}`,
-    };
-  }
-  if (source !== "serviceRegistry") {
-    const reason = source
-      ? `service is projected from ${source}, not service registry`
-      : "service registry posture is missing";
-    return {
-      state: "blocked",
-      reason,
-      label: `blocked / ${reason}`,
-    };
-  }
-  const blockedReasons = normalizedArray(fabric.blockedReasons).map((reason) => String(reason || "").trim()).filter(Boolean);
-  if (String(fabric.state || "").trim() !== "ready" || blockedReasons.length > 0) {
-    const reason = blockedReasons[0] || "host fabric is not ready";
-    return {
-      state: "blocked",
-      reason,
-      label: `blocked / ${reason}`,
-    };
-  }
+  const posture = prepareServiceLaunchPosture(record);
   return {
-    state: "ready",
-    reason: "",
-    label: "ready",
+    state: posture.state,
+    reason: posture.reason,
+    label: posture.label,
   };
 }
 
@@ -221,7 +174,7 @@ function serviceCatalogRecords(snapshot) {
       hostGatewayPk: String(entry.hostGatewayPk || entry.host_gateway_pk || "").trim(),
       label: label || service,
       status: String(health.status || entry.status || "").trim(),
-      hostFabric: hostFabricPosture(entry.hostFabric),
+      hostFabric: prepareServiceHostFabricPosture(entry.hostFabric),
       facts: {
         ...(normalizeObject(entry.facts)),
         health,

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -1,5 +1,7 @@
 import {
   deriveRuntimeMaterializationPosture,
+  prepareRuntimeHostFabricPosture,
+  prepareRuntimeTargetPosture,
   preparedServiceRegistry,
   projectionPostureSummary,
 } from "constitute-ui";
@@ -324,6 +326,8 @@ export function prepareRuntimeSnapshotModel(snapshot, options = {}) {
     materializationBudget: options.materializationBudget,
     consumerFloor: options.consumerFloor,
   });
+  const target = prepareRuntimeTargetPosture(snapshot || {}, options);
+  const fabric = prepareRuntimeHostFabricPosture(snapshot || {}, options);
   return {
     records,
     serviceCatalog: {
@@ -336,6 +340,8 @@ export function prepareRuntimeSnapshotModel(snapshot, options = {}) {
       hostFabricReadyCount: fabricReadyCount,
       hostFabricBlockedCount: fabricBlockedCount,
     },
+    target,
+    fabric,
     edge: prepareSwarmEdgeStatus(snapshot),
     projection: prepareProjectionStatus(snapshot),
     materialization,
@@ -347,6 +353,8 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
   const projection = normalizeObject(prepared?.projection);
   const materialization = normalizeObject(prepared?.materialization);
   const serviceCatalog = normalizeObject(prepared?.serviceCatalog);
+  const target = normalizeObject(prepared?.target);
+  const fabric = normalizeObject(prepared?.fabric);
   const resource = normalizeObject(snapshot?.resource);
   const retention = normalizeObject(snapshot?.retention);
   const resourceReason = postureReason(resource);
@@ -364,6 +372,16 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
       label: "Host fabric",
       value: `${Number(serviceCatalog.hostFabricReadyCount || 0)} ready / ${Number(serviceCatalog.hostFabricBlockedCount || 0)} blocked`,
       tone: Number(serviceCatalog.hostFabricBlockedCount || 0) === 0 && Number(serviceCatalog.hostFabricReadyCount || 0) > 0 ? "good" : "warn",
+    },
+    {
+      label: "Contract target",
+      value: [postureState(target), shortRef(target.targetRef)].filter(Boolean).join(" / "),
+      tone: target.blocked === true ? "bad" : (target.ready === true ? "good" : "warn"),
+    },
+    {
+      label: "Fabric plan",
+      value: [postureState(fabric), shortRef(fabric.planId)].filter(Boolean).join(" / "),
+      tone: fabric.blocked === true ? "bad" : (fabric.ready === true ? "good" : "warn"),
     },
     {
       label: "Swarm edge",

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -49,6 +49,33 @@ function postureReason(value) {
   return String(posture.cleanupReason || posture.reason || posture.blockedReason || "").trim();
 }
 
+function hostFabricPosture(value) {
+  const fabric = normalizeObject(value);
+  if (!Object.keys(fabric).length) {
+    return { state: "missing", blockedReasons: [], label: "missing" };
+  }
+  const state = String(fabric.state || fabric.fulfillmentPlan?.state || fabric.lifecyclePlan?.state || "unknown").trim() || "unknown";
+  const blockedReasons = normalizedArray(fabric.blockedReasons).map((reason) => String(reason || "").trim()).filter(Boolean);
+  const handoffRef = String(fabric.associationHandoffRef || "").trim();
+  return {
+    state,
+    blockedReasons,
+    handoffRef,
+    label: [
+      state,
+      blockedReasons.length ? `blocked ${blockedReasons.slice(0, 2).join(", ")}` : "",
+      handoffRef ? `handoff ${shortRef(handoffRef)}` : "",
+    ].filter(Boolean).join(" / "),
+  };
+}
+
+function shortRef(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  if (raw.length <= 18) return raw;
+  return `${raw.slice(0, 10)}...${raw.slice(-5)}`;
+}
+
 function serviceRecordKey(record) {
   const service = normalizeRole(record?.service || record?.slug || record?.name || "");
   const servicePk = String(record?.devicePk || record?.pk || record?.servicePk || record?.service_pk || "").trim();
@@ -154,6 +181,7 @@ function serviceCatalogRecords(snapshot) {
       hostGatewayPk: String(entry.hostGatewayPk || entry.host_gateway_pk || "").trim(),
       label: label || service,
       status: String(health.status || entry.status || "").trim(),
+      hostFabric: hostFabricPosture(entry.hostFabric),
       facts: {
         ...(normalizeObject(entry.facts)),
         health,
@@ -251,6 +279,9 @@ export function prepareProjectionStatus(snapshot) {
 export function prepareRuntimeSnapshotModel(snapshot, options = {}) {
   const records = normalizeRuntimeRecords(snapshot, options);
   const registry = preparedServiceRegistry(snapshot || {});
+  const serviceRecords = records.filter((record) => normalizeRole(record.service));
+  const fabricReadyCount = serviceRecords.filter((record) => normalizeObject(record.hostFabric).state === "ready").length;
+  const fabricBlockedCount = serviceRecords.filter((record) => normalizedArray(normalizeObject(record.hostFabric).blockedReasons).length > 0).length;
   const materialization = deriveRuntimeMaterializationPosture(snapshot || {}, {
     materializationBudget: options.materializationBudget,
     consumerFloor: options.consumerFloor,
@@ -264,6 +295,8 @@ export function prepareRuntimeSnapshotModel(snapshot, options = {}) {
       state: registry.state,
       claimCount: registry.claimCount,
       entryCount: registry.entryCount,
+      hostFabricReadyCount: fabricReadyCount,
+      hostFabricBlockedCount: fabricBlockedCount,
     },
     edge: prepareSwarmEdgeStatus(snapshot),
     projection: prepareProjectionStatus(snapshot),
@@ -288,6 +321,11 @@ export function runtimeStatusRows(snapshot, prepared, records, fallbackBuildId =
       label: "Service catalog",
       value: `${Number(serviceCatalog.serviceCount || 0)} services / ${serviceCatalog.state || "unknown"}`,
       tone: Number(serviceCatalog.serviceCount || 0) > 0 ? "good" : "warn",
+    },
+    {
+      label: "Host fabric",
+      value: `${Number(serviceCatalog.hostFabricReadyCount || 0)} ready / ${Number(serviceCatalog.hostFabricBlockedCount || 0)} blocked`,
+      tone: Number(serviceCatalog.hostFabricBlockedCount || 0) === 0 && Number(serviceCatalog.hostFabricReadyCount || 0) > 0 ? "good" : "warn",
     },
     {
       label: "Swarm edge",

--- a/src/runtime-model.js
+++ b/src/runtime-model.js
@@ -69,6 +69,44 @@ function hostFabricPosture(value) {
   };
 }
 
+export function serviceLaunchPosture(record) {
+  const source = String(record?.__source || "").trim();
+  const fabric = normalizeObject(record?.hostFabric);
+  const legacyFallback = normalizeObject(record?.legacyPathFallback || record?.legacy_path_fallback);
+  if (Object.keys(legacyFallback).length > 0) {
+    const reason = String(legacyFallback.reason || "legacy path fallback is quarantined").trim();
+    return {
+      state: "blocked",
+      reason,
+      label: `blocked / ${reason}`,
+    };
+  }
+  if (source !== "serviceRegistry") {
+    const reason = source
+      ? `service is projected from ${source}, not service registry`
+      : "service registry posture is missing";
+    return {
+      state: "blocked",
+      reason,
+      label: `blocked / ${reason}`,
+    };
+  }
+  const blockedReasons = normalizedArray(fabric.blockedReasons).map((reason) => String(reason || "").trim()).filter(Boolean);
+  if (String(fabric.state || "").trim() !== "ready" || blockedReasons.length > 0) {
+    const reason = blockedReasons[0] || "host fabric is not ready";
+    return {
+      state: "blocked",
+      reason,
+      label: `blocked / ${reason}`,
+    };
+  }
+  return {
+    state: "ready",
+    reason: "",
+    label: "ready",
+  };
+}
+
 function shortRef(value) {
   const raw = String(value || "").trim();
   if (!raw) return "";

--- a/tests/runtime-model.test.js
+++ b/tests/runtime-model.test.js
@@ -6,6 +6,7 @@ import {
   prepareSwarmEdgeStatus,
   restoreActiveFieldState,
   runtimeStatusRows,
+  serviceLaunchPosture,
 } from "../src/runtime-model.js";
 
 test("runtime model uses retained service catalog records", () => {
@@ -59,6 +60,39 @@ test("runtime model uses retained service catalog records", () => {
   assert.equal(logging.status, "online");
   assert.equal(logging.hostFabric.state, "ready");
   assert.equal(logging.facts.health.events, 42);
+  assert.equal(serviceLaunchPosture(logging).state, "ready");
+});
+
+test("service launch posture blocks non-registry and legacy fallback records", () => {
+  assert.deepEqual(serviceLaunchPosture({
+    service: "nvr",
+    __source: "browserStorageCache",
+    hostFabric: { state: "ready", blockedReasons: [] },
+  }), {
+    state: "blocked",
+    reason: "service is projected from browserStorageCache, not service registry",
+    label: "blocked / service is projected from browserStorageCache, not service registry",
+  });
+
+  assert.deepEqual(serviceLaunchPosture({
+    service: "nvr",
+    __source: "serviceRegistry",
+    hostFabric: { state: "ready", blockedReasons: [] },
+    legacyPathFallback: {
+      state: "legacyPathFallback",
+      reason: "retained cache selected service context",
+    },
+  }), {
+    state: "blocked",
+    reason: "retained cache selected service context",
+    label: "blocked / retained cache selected service context",
+  });
+
+  assert.equal(serviceLaunchPosture({
+    service: "nvr",
+    __source: "serviceRegistry",
+    hostFabric: { state: "blocked", blockedReasons: ["association missing"] },
+  }).reason, "association missing");
 });
 
 test("runtime model surfaces swarm edge queue reject and projection repair status", () => {

--- a/tests/runtime-model.test.js
+++ b/tests/runtime-model.test.js
@@ -31,6 +31,11 @@ test("runtime model uses retained service catalog records", () => {
           hostGatewayPk: "gateway-1",
           health: { status: "online", events: 42, producers: 2, storageStatus: "ok" },
           surface: { summary: "retained logging surface" },
+          hostFabric: {
+            state: "ready",
+            associationHandoffRef: "handoff:gateway:gateway-1:initial-owner",
+            blockedReasons: [],
+          },
         }],
       },
       services: [{
@@ -46,10 +51,13 @@ test("runtime model uses retained service catalog records", () => {
   assert.equal(prepared.serviceCatalog.source, "serviceRegistry");
   assert.equal(prepared.serviceCatalog.state, "ready");
   assert.equal(prepared.serviceCatalog.claimCount, 1);
+  assert.equal(prepared.serviceCatalog.hostFabricReadyCount, 1);
+  assert.equal(prepared.serviceCatalog.hostFabricBlockedCount, 0);
   assert.equal(prepared.records.some((record) => record.role === "gateway"), true);
   const logging = prepared.records.find((record) => record.service === "logging");
   assert.equal(logging.__source, "serviceRegistry");
   assert.equal(logging.status, "online");
+  assert.equal(logging.hostFabric.state, "ready");
   assert.equal(logging.facts.health.events, 42);
 });
 
@@ -120,6 +128,7 @@ test("runtime model surfaces swarm edge queue reject and projection repair statu
     tone: "warn",
   });
   assert.equal(rows.find((row) => row.label === "Service catalog").value, "0 services / missing");
+  assert.equal(rows.find((row) => row.label === "Host fabric").value, "0 ready / 0 blocked");
   assert.equal(rows.find((row) => row.label === "Projection sync").value, "1 retained / completeEnough 1");
   assert.deepEqual(rows.find((row) => row.label === "Resource posture"), {
     label: "Resource posture",

--- a/tests/runtime-model.test.js
+++ b/tests/runtime-model.test.js
@@ -8,6 +8,7 @@ import {
   runtimeStatusRows,
   serviceLaunchPosture,
 } from "../src/runtime-model.js";
+import { FABRIC, SWARM } from "constitute-protocol";
 
 test("runtime model uses retained service catalog records", () => {
   const snapshot = {
@@ -174,6 +175,68 @@ test("runtime model surfaces swarm edge queue reject and projection repair statu
     value: "releaseRequired / retention blockers active",
     tone: "warn",
   });
+});
+
+test("runtime model consumes shared target and fabric read-model posture", () => {
+  const snapshot = {
+    buildId: "runtime-test",
+    updatedAt: Date.now(),
+    targetSource: {
+      kind: "runtime.contract-target.source",
+      contractTargets: [{
+        kind: SWARM.RECORD_KIND.CONTRACT_TARGET,
+        targetRef: "contract-target:desktop-windows-dev:msa-transition",
+        contractRef: "app:constitution-runtime-target@msa-transition",
+        profileRef: "target-profile:desktop-dev",
+        platformRef: "platform:windows-desktop",
+        state: FABRIC.CONTRACT_TARGET_STATE.DEGRADED,
+        compatibilityState: FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.DEGRADED,
+        modifierRefs: ["modifier:dev"],
+        branchRefs: ["branch:0x/msa-transition"],
+        capabilitySlotRefs: ["slot:runtime", "slot:native-client"],
+        missingSlotRefs: ["slot:native-client"],
+        proofProfileRefs: ["proof-profile:surface-landscape"],
+        evidenceRefs: ["evidence:runtime:target-source"],
+        blockedReasons: ["nativeClientNotPresentOnDesktopDevTarget"],
+        targetAudience: "operator",
+        issuedAt: 1778720000000,
+        expiresAt: 1778720060000,
+      }],
+      targetRegistryPostures: [{
+        kind: SWARM.RECORD_KIND.CONTRACT_TARGET_REGISTRY_POSTURE,
+        registryRef: "contract-target-registry:desktop-windows-dev:msa-transition",
+        targetRef: "contract-target:desktop-windows-dev:msa-transition",
+        contractRef: "app:constitution-runtime-target@msa-transition",
+        state: FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED,
+        slotPostures: [{
+          slotRef: "slot:runtime",
+          state: FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+          platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+          candidateFulfillmentRefs: ["runtime:runtime-test"],
+          selectedFulfillmentRef: "runtime:runtime-test",
+        }, {
+          slotRef: "slot:native-client",
+          state: FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING,
+          platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.UNKNOWN,
+          blockedReasons: ["nativeClientNotPresentOnDesktopDevTarget"],
+        }],
+        candidateFulfillmentRefs: ["runtime:runtime-test"],
+        proofRequirementRefs: ["proof-requirement:surface-landscape"],
+        evidenceRefs: ["evidence:runtime:target-registry"],
+        blockedReasons: ["nativeClientNotPresentOnDesktopDevTarget"],
+        observedAt: 1778720000100,
+        expiresAt: 1778720060000,
+      }],
+    },
+  };
+
+  const prepared = prepareRuntimeSnapshotModel(snapshot);
+  const rows = runtimeStatusRows(snapshot, prepared, prepared.records, "runtime-fallback");
+
+  assert.equal(prepared.target.targetRef, "contract-target:desktop-windows-dev:msa-transition");
+  assert.equal(prepared.target.state, "degraded");
+  assert.equal(rows.some((row) => row.label === "Contract target" && row.tone === "warn"), true);
+  assert.equal(rows.some((row) => row.label === "Fabric plan" && row.value.includes("pending")), true);
 });
 
 test("active field state can survive a projection snapshot render", () => {


### PR DESCRIPTION
Moves Gateway UI to shared service target/read-model helpers and removes duplicated host-fabric reducer truth.\n\nProof: local Gateway UI tests/build, browser, convergence, affected, aggregate, and 10-minute media/resource proof passed.